### PR TITLE
Add inventory alert type to item variation

### DIFF
--- a/objects/catalog_item_variation.go
+++ b/objects/catalog_item_variation.go
@@ -13,23 +13,79 @@ const (
 )
 
 type CatalogItemVariation struct {
-	ItemID                  string                                    `json:"item_id,omitempty"`
-	Name                    string                                    `json:"name,omitempty"`
-	Sku                     string                                    `json:"sku,omitempty"`
-	Upc                     string                                    `json:"string,omitempty"`
-	Ordinal                 int                                       `json:"ordinal,omitempty"`
-	PricingType             CatalogPricingType                        `json:"pricing_type,omitempty"`
-	PriceMoney              *Money                                    `json:"price_money,omitempty"`
-	LocationOverrides       []*ItemVariationLocationOverrides         `json:"location_overrides,omitempty"`
-	TrackInventory          bool                                      `json:"track_inventory,omitempty"`
-	InventoryAlertType      string                                    `json:"inventory_alert_type,omitempty"`
-	InventoryAlertThreshold int                                       `json:"inventory_alert_threshold,omitempty"`
-	UserData                string                                    `json:"user_data,omitempty"`
-	ServiceDuration         int                                       `json:"service_duration,omitempty"`
-	AvailableForBooking     bool                                      `json:"available_for_booking,omitempty"`
-	ItemOptionValues        []*CatalogItemOptionValueForItemVariation `json:"item_option_values,omitempty"`
-	MeasurementUnitID       string                                    `json:"measurement_unit_id,omitempty"`
-	TeamMemberIDs           []string                                  `json:"team_member_ids,omitempty"`
+	ItemID              string                                    `json:"item_id,omitempty"`
+	Name                string                                    `json:"name,omitempty"`
+	Sku                 string                                    `json:"sku,omitempty"`
+	Upc                 string                                    `json:"string,omitempty"`
+	Ordinal             int                                       `json:"ordinal,omitempty"`
+	PricingType         CatalogPricingType                        `json:"pricing_type,omitempty"`
+	PriceMoney          *Money                                    `json:"price_money,omitempty"`
+	LocationOverrides   []*ItemVariationLocationOverrides         `json:"location_overrides,omitempty"`
+	TrackInventory      bool                                      `json:"track_inventory,omitempty"`
+	InventoryAlertType  InventoryAlertType                        `json:"-"`
+	UserData            string                                    `json:"user_data,omitempty"`
+	ServiceDuration     int                                       `json:"service_duration,omitempty"`
+	AvailableForBooking bool                                      `json:"available_for_booking,omitempty"`
+	ItemOptionValues    []*CatalogItemOptionValueForItemVariation `json:"item_option_values,omitempty"`
+	MeasurementUnitID   string                                    `json:"measurement_unit_id,omitempty"`
+	TeamMemberIDs       []string                                  `json:"team_member_ids,omitempty"`
+}
+
+type catalogItemVariationAlias CatalogItemVariation
+
+type catalogItemVariation struct {
+	*catalogItemVariationAlias
+	InventoryAlertType      inventoryAlertType `json:"inventory_alert_type,omitempty"`
+	InventoryAlertThreshold int                `json:"inventory_alert_threshold,omitempty"`
+}
+
+func (c *CatalogItemVariation) MarshalJSON() ([]byte, error) {
+	jsonType := &catalogItemVariation{
+		catalogItemVariationAlias: (*catalogItemVariationAlias)(c),
+	}
+
+	if c.InventoryAlertType != nil {
+		switch t := c.InventoryAlertType.(type) {
+		case *InventoryAlertTypeNone:
+			jsonType.InventoryAlertType = inventoryAlertTypeNone
+		case *InventoryAlertTypeLowQuantity:
+			jsonType.InventoryAlertType = inventoryAlertTypeLowQuantity
+			jsonType.InventoryAlertThreshold = t.Threshold
+		default:
+			return nil, fmt.Errorf("unknown inventory alert type found")
+		}
+	}
+
+	b, err := json.Marshal(jsonType)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling item variation: %w", err)
+	}
+
+	return b, nil
+}
+
+func (c *CatalogItemVariation) UnmarshalJSON(bytes []byte) error {
+	jsonType := catalogItemVariation{
+		catalogItemVariationAlias: (*catalogItemVariationAlias)(c),
+	}
+
+	if err := json.Unmarshal(bytes, &jsonType); err != nil {
+		return fmt.Errorf("error unmarshaling item variation: %w", err)
+	}
+
+	switch jsonType.InventoryAlertType {
+	case "": // Do nothing.
+	case inventoryAlertTypeNone:
+		c.InventoryAlertType = &InventoryAlertTypeNone{}
+	case inventoryAlertTypeLowQuantity:
+		c.InventoryAlertType = &InventoryAlertTypeLowQuantity{
+			Threshold: jsonType.InventoryAlertThreshold,
+		}
+	default:
+		return fmt.Errorf("unknown inventory alert type found: %s", jsonType.InventoryAlertType)
+	}
+
+	return nil
 }
 
 type InventoryAlertType interface {
@@ -72,14 +128,16 @@ func (o *ItemVariationLocationOverrides) MarshalJSON() ([]byte, error) {
 		itemVariationLocationOverridesAlias: (*itemVariationLocationOverridesAlias)(o),
 	}
 
-	switch t := o.InventoryAlertType.(type) {
-	case *InventoryAlertTypeNone:
-		jsonType.InventoryAlertType = inventoryAlertTypeNone
-	case *InventoryAlertTypeLowQuantity:
-		jsonType.InventoryAlertType = inventoryAlertTypeLowQuantity
-		jsonType.InventoryAlertThreshold = t.Threshold
-	default:
-		return nil, fmt.Errorf("unknown inventory alert type found")
+	if o.InventoryAlertType != nil {
+		switch t := o.InventoryAlertType.(type) {
+		case *InventoryAlertTypeNone:
+			jsonType.InventoryAlertType = inventoryAlertTypeNone
+		case *InventoryAlertTypeLowQuantity:
+			jsonType.InventoryAlertType = inventoryAlertTypeLowQuantity
+			jsonType.InventoryAlertThreshold = t.Threshold
+		default:
+			return nil, fmt.Errorf("unknown inventory alert type found")
+		}
 	}
 
 	b, err := json.Marshal(jsonType)
@@ -100,6 +158,7 @@ func (o *ItemVariationLocationOverrides) UnmarshalJSON(bytes []byte) error {
 	}
 
 	switch jsonType.InventoryAlertType {
+	case "": // Do Nothing.
 	case inventoryAlertTypeNone:
 		o.InventoryAlertType = &InventoryAlertTypeNone{}
 	case inventoryAlertTypeLowQuantity:


### PR DESCRIPTION
Can't just put it on the overrides, has to exist on the regular item
variation as well