### PR TITLE
Change custom attribute definition defaults

### DIFF
--- a/objects/catalog_custom_attribute_definition.go
+++ b/objects/catalog_custom_attribute_definition.go
@@ -41,12 +41,12 @@ type catalogCustomAttributeDefinition struct {
 type catalogCustomAttributeDefinitionAlias CatalogCustomAttributeDefinition
 
 type CatalogCustomAttributeDefinitionNumberConfig struct {
-	Precision int `json:"precision,omitempty"`
+	Precision *int `json:"precision,omitempty"`
 }
 
 type CatalogCustomAttributeDefinitionSelectionConfig struct {
 	AllowedSelections    []*CatalogCustomAttributeDefinitionSelectionConfigCustomAttributeSelection `json:"allowed_selections,omitempty"`
-	MaxAllowedSelections int                                                                        `json:"max_allowed_selections,omitempty"`
+	MaxAllowedSelections *int                                                                       `json:"max_allowed_selections,omitempty"`
 }
 
 type CatalogCustomAttributeDefinitionSelectionConfigCustomAttributeSelection struct {


### PR DESCRIPTION
Some fields in custom attribute definition have non-zero defaults and
therefore should be set with pointers (so that the zero value is
relevant)